### PR TITLE
Added switch to dis/allow rotation of boxes within the bin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ rvm:
   - 1.9.3
   - 2.2.0
   - jruby-19mode
-  - rbx-2
+  - 2.4
+  - 2.5
+
 script: bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: ruby
-dist: trusty
 before_install:
   - rm Gemfile.lock
 rvm:
   - 1.9.3
-  - 2.2.0
-  - jruby-19mode
+  - 2.2
+  - 2.3
   - 2.4
   - 2.5
-
+  - jruby-19mode
 script: bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: trusty
 before_install:
   - rm Gemfile.lock
 rvm:

--- a/lib/bin_packing/box.rb
+++ b/lib/bin_packing/box.rb
@@ -1,13 +1,14 @@
 module BinPacking
   class Box
-    attr_accessor :width, :height, :x, :y, :packed
+    attr_accessor :width, :height, :x, :y, :packed, :can_rotate
 
-    def initialize(width, height)
+    def initialize(width, height, can_rotate: true)
       @width = width
       @height = height
       @x = 0
       @y = 0
       @packed = false
+      @can_rotate = can_rotate
     end
 
     def area
@@ -20,6 +21,10 @@ module BinPacking
 
     def packed?
       @packed
+    end
+
+    def can_rotate?
+      @can_rotate
     end
 
     def label

--- a/lib/bin_packing/box.rb
+++ b/lib/bin_packing/box.rb
@@ -15,10 +15,6 @@ module BinPacking
       @area ||= @width * @height
     end
 
-    def rotate
-      @width, @height = [@height, @width]
-    end
-
     def packed?
       @packed
     end

--- a/lib/bin_packing/box.rb
+++ b/lib/bin_packing/box.rb
@@ -2,13 +2,13 @@ module BinPacking
   class Box
     attr_accessor :width, :height, :x, :y, :packed, :can_rotate
 
-    def initialize(width, height, can_rotate: true)
+    def initialize(width, height)
       @width = width
       @height = height
       @x = 0
       @y = 0
       @packed = false
-      @can_rotate = can_rotate
+      @can_rotate = true
     end
 
     def area

--- a/lib/bin_packing/heuristics/base.rb
+++ b/lib/bin_packing/heuristics/base.rb
@@ -8,7 +8,10 @@ module BinPacking
 
         free_rectangles.each do |free_rect|
           try_place_rect_in(free_rect, box, width, height, best_score)
-          try_place_rect_in(free_rect, box, height, width, best_score)
+
+          if box.can_rotate?
+            try_place_rect_in(free_rect, box, height, width, best_score)
+          end
         end
 
         best_score

--- a/spec/bin_packing/packer_spec.rb
+++ b/spec/bin_packing/packer_spec.rb
@@ -112,6 +112,24 @@ describe BinPacking::Packer do
       expect(packer.pack([box]).size).to be 1
       expect(packer.pack([box]).size).to be 0
     end
+
+    it 'respects the can_rotate property' do
+      bin = bin_of_size_1
+      box = BinPacking::Box.new(1_000, 9_000, can_rotate: false)
+      packer = BinPacking::Packer.new([bin])
+      expect(packer.pack([box]).size).to be 0
+      expect(bin.boxes.size).to be 0
+      expect(box.width).to be 1_000
+      expect(box.height).to be 9_000
+      expect(box.packed?).to be false
+
+      bin = bin_of_size_1
+      box = BinPacking::Box.new(1_000, 9_000, can_rotate: true)
+      packer = BinPacking::Packer.new([bin])
+      expect(packer.pack([box]).size).to be 1
+      expect(bin.boxes.size).to be 1
+      expect(box.packed?).to be true
+    end
   end
 
   describe '#pack!' do

--- a/spec/bin_packing/packer_spec.rb
+++ b/spec/bin_packing/packer_spec.rb
@@ -115,7 +115,8 @@ describe BinPacking::Packer do
 
     it 'respects the can_rotate property' do
       bin = bin_of_size_1
-      box = BinPacking::Box.new(1_000, 9_000, can_rotate: false)
+      box = BinPacking::Box.new(1_000, 9_000)
+      box.can_rotate = false
       packer = BinPacking::Packer.new([bin])
       expect(packer.pack([box]).size).to be 0
       expect(bin.boxes.size).to be 0
@@ -124,7 +125,8 @@ describe BinPacking::Packer do
       expect(box.packed?).to be false
 
       bin = bin_of_size_1
-      box = BinPacking::Box.new(1_000, 9_000, can_rotate: true)
+      box = BinPacking::Box.new(1_000, 9_000)
+      box.can_rotate = true
       packer = BinPacking::Packer.new([bin])
       expect(packer.pack([box]).size).to be 1
       expect(bin.boxes.size).to be 1


### PR DESCRIPTION
WHY
Implementation of Bin packing algorithm is good, however we have added restriction to not allow rotation of boxes.

HOW
update rspec tests to verify the base packer heuristic does not rotate boxes.